### PR TITLE
added support for http and https interception on Android

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -1,19 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
         xmlns:android="http://schemas.android.com/apk/res/android"
-        id="nl.x-services.plugins.launchmyapp"
-        version="3.1.1">
+        id="com.machenmusik.plugins.launchmyapp"
+        version="3.1.2">
 
   <name>Custom URL scheme</name>
 
   <description>
     Launch your app by using this URL:  mycoolapp://
     You can add a path and even pass params like this: mycoolerapp://somepath?foo=bar
+    Now also adds http and https handling for Android
   </description>
 
   <license>MIT</license>
 
   <preference name="URL_SCHEME" />
+  <preference name="HTTP_HOST" />
+  <preference name="HTTP_PATHPREFIX" />
+  <preference name="HTTPS_HOST" />
+  <preference name="HTTPS_PATHPREFIX" />
 
   <engines>
     <engine name="cordova" version=">=3.0.0"/>
@@ -54,6 +59,8 @@
     <config-file target="AndroidManifest.xml" parent="/*/application/activity">
       <intent-filter>
         <data android:scheme="$URL_SCHEME"/>
+        <data android:scheme="http" android:host="$HTTP_HOST" android:pathPrefix="$HTTP_PATHPREFIX"/>
+        <data android:scheme="https" android:host="$HTTPS_HOST" android:pathPrefix="$HTTPS_PATHPREFIX"/>
         <action android:name="android.intent.action.VIEW" />
         <category android:name="android.intent.category.DEFAULT" />
         <category android:name="android.intent.category.BROWSABLE" />


### PR DESCRIPTION
CAVEAT -- untested at present, I've only been able to create apps using PhoneGap Build, and I've had to submit the fork as a separate plugin temporarily, so that I will hopefully be able to confirm this change functions properly if it is accepted.  Not sure exactly what it will do with empty values for HTTP and HTTPS (e.g. will empty host match none, or match all?) so not sure it's safe to auto-merge just yet.
