### PR TITLE
Fix for meteor android

### DIFF
--- a/src/android/nl/xservices/plugins/LaunchMyApp.java
+++ b/src/android/nl/xservices/plugins/LaunchMyApp.java
@@ -16,15 +16,19 @@ import java.util.Locale;
 public class LaunchMyApp extends CordovaPlugin {
 
   private static final String ACTION_CHECKINTENT = "checkIntent";
+  private static final String ACTION_CLEARINTENT = "clearIntent";
 
   @Override
   public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
-    if (ACTION_CHECKINTENT.equalsIgnoreCase(action)) {
+    if (ACTION_CLEARINTENT.equalsIgnoreCase(action)) {
+      final Intent intent = ((CordovaActivity) this.webView.getContext()).getIntent();
+      intent.setData(null);
+      return true;
+    } else if (ACTION_CHECKINTENT.equalsIgnoreCase(action)) {
       final Intent intent = ((CordovaActivity) this.webView.getContext()).getIntent();
       final String intentString = intent.getDataString();
       if (intentString != null && intent.getScheme() != null) {
         callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, intent.getDataString()));
-        intent.setData(null);
       } else {
         callbackContext.error("App was not started via the launchmyapp URL scheme. Ignoring this errorcallback is the best approach.");
       }

--- a/www/android/LaunchMyApp.js
+++ b/www/android/LaunchMyApp.js
@@ -4,10 +4,18 @@
   var remainingAttempts = 10;
 
   function waitForAndCallHandlerFunction(url) {
-    if (typeof window.handleOpenURL == "function") {
+    if (typeof window.handleOpenURL === "function") {
+      // Clear the intent when we have a handler
+      cordova.exec(
+          null,
+          null,
+          "LaunchMyApp",
+          "clearIntent",
+          []);
+
       window.handleOpenURL(url);
     } else if (remainingAttempts-- > 0) {
-      setTimeout(function(){waitForAndCallHandlerFunction(url)}, 500);
+      setTimeout(function(){waitForAndCallHandlerFunction(url);}, 500);
     }
   }
 


### PR DESCRIPTION
Thank you @EddyVerbruggen for your package, I’m using it in a Meteor.js
package and while doing so I stumbled on an issue.

The intent gets cleared even if theres no handler, this pr adds a clear
intent command and runs this when calling the handle.

The issue in Meteor is that theres a update mech (the initial page)
when done it redirects to the actual app - the intent would be cleared
in the initial page and the handle in the app would not trigger.

Let me know if you have additional questions or concerns about the fix