### PR TITLE
save lastIntentString in java and get it from javascript with getLastIntent()

### DIFF
--- a/src/android/nl/xservices/plugins/LaunchMyApp.java
+++ b/src/android/nl/xservices/plugins/LaunchMyApp.java
@@ -19,6 +19,8 @@ public class LaunchMyApp extends CordovaPlugin {
   private static final String ACTION_CLEARINTENT = "clearIntent";
   private static final String ACTION_GETLASTINTENT = "getLastIntent";
 
+  private String lastIntentString = null;
+
   @Override
   public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
     if (ACTION_CLEARINTENT.equalsIgnoreCase(action)) {

--- a/src/android/nl/xservices/plugins/LaunchMyApp.java
+++ b/src/android/nl/xservices/plugins/LaunchMyApp.java
@@ -17,6 +17,7 @@ public class LaunchMyApp extends CordovaPlugin {
 
   private static final String ACTION_CHECKINTENT = "checkIntent";
   private static final String ACTION_CLEARINTENT = "clearIntent";
+  private static final String ACTION_GETLASTINTENT = "getLastIntent";
 
   @Override
   public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
@@ -28,9 +29,17 @@ public class LaunchMyApp extends CordovaPlugin {
       final Intent intent = ((CordovaActivity) this.webView.getContext()).getIntent();
       final String intentString = intent.getDataString();
       if (intentString != null && intent.getScheme() != null) {
+	 lastIntentString = intentString;
         callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, intent.getDataString()));
       } else {
         callbackContext.error("App was not started via the launchmyapp URL scheme. Ignoring this errorcallback is the best approach.");
+      }
+      return true;
+    } else if (ACTION_GETLASTINTENT.equalsIgnoreCase(action)) {
+      if(lastIntentString != null) {
+        callbackContext.sendPluginResult(new PluginResult(PluginResult.Status.OK, lastIntentString));
+      } else {
+        callbackContext.error("No intent received so far.");
       }
       return true;
     } else {

--- a/www/android/LaunchMyApp.js
+++ b/www/android/LaunchMyApp.js
@@ -30,13 +30,17 @@
 
   document.addEventListener("deviceready", triggerOpenURL, false);
 
-  function getLastIntent(success, failure) {
-    cordova.exec(
-      success,
-      failure,
-      "LaunchMyApp",
-      "getLastIntent",
-      []);
+  var launchmyapp = {
+    getLastIntent: function(success, failure) {
+      cordova.exec(
+        success,
+        failure,
+        "LaunchMyApp",
+        "getLastIntent",
+        []);
+    }
   }
+
+  module.exports = launchmyapp;
 
 }());

--- a/www/android/LaunchMyApp.js
+++ b/www/android/LaunchMyApp.js
@@ -29,4 +29,14 @@
   }
 
   document.addEventListener("deviceready", triggerOpenURL, false);
+
+  function getLastIntent(success, failure) {
+    cordova.exec(
+      success,
+      failure,
+      "LaunchMyApp",
+      "getLastIntent",
+      []);
+  }
+
 }());


### PR DESCRIPTION
hi! I added the functionality to query for the last intent string out of javascript. I did this in order to make your cool plugin work from a cold start with meteor's cordova environment (see https://github.com/EddyVerbruggen/Custom-URL-scheme/issues/98). As far as I was able to understand it the problem arrives from the fact, that the android app starts from one url then meteor/cordova intercepts and calls another url in the webview. This resets javascript's world / window. I see launchmyapp waiting for handleOpenURL to be present on window but suddenly everything, including the timer is gone and handleOpenURL never get's called. What I do now is to save the last intent string in a variable in java and query with getLastIntent out of meteor like this
```
    window.plugins.launchmyapp.getLastIntent( (intent)->
      if intent.indexOf 'myawesomeapp://' > -1
        # handle intent
      else
        console.log "ignore intent: #{intent}"
    , (error) ->
      console.log "no intent received"
    )
```
Sorry, I don't have time right now to implement the functionality the other platforms right now, so I'd understand if you don't want to merge.