### PR TITLE
Windows 10 manifest support.

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -84,6 +84,12 @@
 
   <!-- windows -->
   <platform name="windows">
+    <hook type="before_prepare" src="src/windows/hooks/prepare-manifest.js" />
+    <config-file target="package.windows10.appxmanifest" parent="/Package/Applications/Application/Extensions">
+      <uap:Extension Category="windows.protocol" StartPage="www/index.html">
+        <uap:Protocol Name="$URL_SCHEME" />
+      </uap:Extension>
+    </config-file>
     <config-file target="package.windows.appxmanifest" parent="/Package/Applications/Application/Extensions">
       <Extension Category="windows.protocol" StartPage="www/index.html">
         <Protocol Name="$URL_SCHEME" />

--- a/src/windows/hooks/prepare-manifest.js
+++ b/src/windows/hooks/prepare-manifest.js
@@ -1,0 +1,30 @@
+module.exports = function(context) {
+    var fs = context.requireCordovaModule('fs'),
+        et = context.requireCordovaModule('elementtree'),
+        path = context.requireCordovaModule('path'),
+        xml= context.requireCordovaModule('cordova-common').xmlHelpers,
+        projectRoot = path.join(context.opts.projectRoot, "platforms", "windows");
+
+    var MANIFEST_WINDOWS    = 'package.windows.appxmanifest',
+        MANIFEST_PHONE      = 'package.phone.appxmanifest',
+        MANIFEST_WINDOWS10  = 'package.windows10.appxmanifest',
+        MANIFEST_WINDOWS80  = 'package.windows80.appxmanifest';
+
+    function updateManifestFile(manifestPath) {
+        var doc = xml.parseElementtreeSync(manifestPath);
+        var root = doc.getroot();
+        var app = root.find('./Applications/Application');
+        if (!app) {
+            throw new Error(manifestPath + ' has incorrect XML structure.');
+        }
+        if (!app.find('./Extensions')) {
+            app.append(new et.Element('Extensions'));
+        }
+        fs.writeFileSync(manifestPath, doc.write({indent: 4}), 'utf-8');
+    }
+
+    [MANIFEST_PHONE, MANIFEST_WINDOWS80, MANIFEST_WINDOWS, MANIFEST_WINDOWS10]
+    .forEach(function(manifestFile) {
+        updateManifestFile(path.join(projectRoot, manifestFile));
+    });
+}


### PR DESCRIPTION
Adding support for Windows 10 solution (package.windows10.appxmanifest file is not supported now), plus creating missing XML parent elements in manifest files using a hook (cordova-windows templates don't contain required "Extensions" elements thus giving build errors).