### PR TITLE
Removing StartPage attribute

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -98,22 +98,22 @@
   <platform name="windows">
     <hook type="before_prepare" src="src/windows/hooks/prepare-manifest.js" />
     <config-file target="package.windows10.appxmanifest" parent="/Package/Applications/Application/Extensions">
-      <uap:Extension Category="windows.protocol" StartPage="www/index.html">
+      <uap:Extension Category="windows.protocol">
         <uap:Protocol Name="$URL_SCHEME" />
       </uap:Extension>
     </config-file>
     <config-file target="package.windows.appxmanifest" parent="/Package/Applications/Application/Extensions">
-      <Extension Category="windows.protocol" StartPage="www/index.html">
+      <Extension Category="windows.protocol">
         <Protocol Name="$URL_SCHEME" />
       </Extension>
     </config-file>
     <config-file target="package.windows80.appxmanifest" parent="/Package/Applications/Application/Extensions">
-      <Extension Category="windows.protocol" StartPage="www/index.html">
+      <Extension Category="windows.protocol">
         <Protocol Name="$URL_SCHEME" />
       </Extension>
     </config-file>
     <config-file target="package.phone.appxmanifest" parent="/Package/Applications/Application/Extensions">
-      <Extension Category="windows.protocol" StartPage="www/index.html">
+      <Extension Category="windows.protocol">
         <Protocol Name="$URL_SCHEME" />
       </Extension>
     </config-file>


### PR DESCRIPTION
Pull request for #179.

I removed the StartPage attribute from the Plugin.xml for windows. With the attribute opening a link would cause the app to reload and would not call the handleOpenUrl function.