### PR TITLE
Handle non-existing Windows manifest file

### DIFF
--- a/src/windows/hooks/prepare-manifest.js
+++ b/src/windows/hooks/prepare-manifest.js
@@ -11,6 +11,10 @@ module.exports = function(context) {
         MANIFEST_WINDOWS80  = 'package.windows80.appxmanifest';
 
     function updateManifestFile(manifestPath) {
+        if (!fs.existsSync(manifestPath)) {
+            return;
+        }
+
         var doc = xml.parseElementtreeSync(manifestPath);
         var root = doc.getroot();
         var app = root.find('./Applications/Application');


### PR DESCRIPTION
Windows 8 support has been removed in the latest cordova-windows releases, so there's no package.windows80.appxmanifest file anymore. This caused the prepare-manifest hook script to fail.

This fixes the problem by checking if the file exists before attempting to parse the xml.