### PR TITLE
Use builtin Cordova event to retrieve URL on Windows

### DIFF
--- a/www/windows/LaunchMyApp.js
+++ b/www/windows/LaunchMyApp.js
@@ -1,10 +1,9 @@
 (function () {
-	function activatedHandler(e) {
-		if (typeof handleOpenURL == 'function' && e.uri) {
-			handleOpenURL(e.uri.rawUri);
-		}
-	};
-	
-	var wui = Windows.UI.WebUI.WebUIApplication;
-	wui.addEventListener("activated", activatedHandler, false);
+    function activatedHandler(e) {
+        if (typeof handleOpenURL === "function" && e.uri) {
+            handleOpenURL(e.uri.rawUri);
+        }
+    };
+
+    document.addEventListener("activated", activatedHandler, false);
 }());


### PR DESCRIPTION
Starting with [Cordova-Windows 4.4.0](https://cordova.apache.org/announcements/2016/06/03/cordova-windows-4.4.0.html) ([CB-10653](https://issues.apache.org/jira/browse/CB-10653) specifically), the 'activated' event, which is being fired by Cordova, contains everything needed to retrieve the URL that was used to launch the app.

As a result, it's not necessary anymore to call Windows APIs from the plugin.