### PR TITLE
URLEncode url passed to WebView loadUrl call on Android

### DIFF
--- a/src/android/nl/xservices/plugins/LaunchMyApp.java
+++ b/src/android/nl/xservices/plugins/LaunchMyApp.java
@@ -13,6 +13,7 @@ import org.json.JSONException;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.io.Writer;
+import java.net.URLEncoder;
 import java.util.Locale;
 
 public class LaunchMyApp extends CordovaPlugin {
@@ -80,7 +81,7 @@ public class LaunchMyApp extends CordovaPlugin {
       try {
         StringWriter writer = new StringWriter(intentString.length() * 2);
         escapeJavaStyleString(writer, intentString, true, false);
-        webView.loadUrl("javascript:handleOpenURL('" + writer.toString() + "');");
+        webView.loadUrl("javascript:handleOpenURL('" + URLEncoder.encode(writer.toString()) + "');");
       } catch (IOException ignore) {
       }
     }


### PR DESCRIPTION
Otherwise e.g. query parameters in the intentstring with values that contain url-encoded ampersands and equalsigns will become corrupt since they are urldecoded before they reach the javascript function.