### PR TITLE
Replace requireCordovaModule() with require()

### DIFF
--- a/src/windows/hooks/prepare-manifest.js
+++ b/src/windows/hooks/prepare-manifest.js
@@ -1,7 +1,7 @@
 module.exports = function(context) {
-    var fs = context.requireCordovaModule('fs'),
-        et = context.requireCordovaModule('elementtree'),
-        path = context.requireCordovaModule('path'),
+    var fs = require('fs'),
+        et = require('elementtree'),
+        path = require('path'),
         xml= context.requireCordovaModule('cordova-common').xmlHelpers,
         projectRoot = path.join(context.opts.projectRoot, "platforms", "windows");
 

--- a/src/wp8/hooks/add-uri-mapper.js
+++ b/src/wp8/hooks/add-uri-mapper.js
@@ -1,7 +1,7 @@
 module.exports  = function (context) {
-    var deferred = context.requireCordovaModule('q').defer(),
-        fs = context.requireCordovaModule('fs'),
-        path = context.requireCordovaModule('path'),
+    var deferred = require('q').defer(),
+        fs = require('fs'),
+        path = require('path'),
         projectRoot = context.opts.projectRoot;
         
     // While on AppBuilder this may work, the Cordova CLI doesn't like it


### PR DESCRIPTION
Cordova 9 throws an error when plugins use `requireCordovaModule()` for packages that aren't Cordova-related (see https://github.com/apache/cordova-cli/issues/416). This addresses that error in a few places used by Windows.