### PR TITLE
Add Preference to support a custom Windows Start Page

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -83,8 +83,10 @@
 
   <!-- windows8 -->
   <platform name="windows8">
+    <preference name="WINDOWS_START_PAGE" default="www/index.html" />
+
     <config-file target="package.appxmanifest" parent="/Package/Applications/Application/Extensions">
-      <Extension Category="windows.protocol" StartPage="www/index.html">
+      <Extension Category="windows.protocol" StartPage="$WINDOWS_START_PAGE">
         <Protocol Name="$URL_SCHEME" />
       </Extension>
     </config-file>
@@ -96,18 +98,20 @@
 
   <!-- windows -->
   <platform name="windows">
+    <preference name="WINDOWS_START_PAGE" default="www/index.html" />
+
     <config-file target="package.windows.appxmanifest" parent="/Package/Applications/Application/Extensions">
-      <uap:Extension Category="windows.protocol" StartPage="www/index.html">
+      <uap:Extension Category="windows.protocol" StartPage="$WINDOWS_START_PAGE">
         <uap:Protocol Name="$URL_SCHEME" />
       </uap:Extension>
     </config-file>
     <config-file target="package.windows10.appxmanifest" parent="/Package/Applications/Application/Extensions">
-      <uap:Extension Category="windows.protocol" StartPage="www/index.html">
+      <uap:Extension Category="windows.protocol" StartPage="$WINDOWS_START_PAGE">
         <uap:Protocol Name="$URL_SCHEME" />
       </uap:Extension>
     </config-file>
     <config-file target="package.phone.appxmanifest" parent="/Package/Applications/Application/Extensions">
-      <uap:Extension Category="windows.protocol" StartPage="www/index.html">
+      <uap:Extension Category="windows.protocol" StartPage="$WINDOWS_START_PAGE">
         <uap:Protocol Name="$URL_SCHEME" />
       </uap:Extension>
     </config-file>


### PR DESCRIPTION
This plugin currently assumes www/index.html is the entry point for all Windows applications.  If you use a different entry point, the plugin causes the builds to fail to compile.

This PR adds a preference to allow the user to specify the StartPage for the Windows protocol.

New preference name: WINDOWS_START_PAGE
I believe this is in line with the current ANDROID_ preferences naming.
